### PR TITLE
CLI enhancements (show/install unstable and RC releases; check deps)

### DIFF
--- a/src/Console/AppConsole.vala
+++ b/src/Console/AppConsole.vala
@@ -93,6 +93,7 @@ public class AppConsole : GLib.Object {
 		msg += "  --purge-old-kernels " + _("Remove installed kernels older than running kernel") + "\n";
 		msg += "  --download <name>   " + _("Download packages for specified kernel") + "\n";
 		msg += "  --clean-cache       " + _("Remove files from application cache") + "\n";
+		msg += "  --show-unstable     " + _("Show unstable and RC releases") + "\n";
 		msg += "\n";
 		msg += _("Options") + ":\n";
 		msg += "\n";
@@ -171,6 +172,10 @@ public class AppConsole : GLib.Object {
 				cmd = args[k].down();
 				break;
 			
+			case "--show-unstable":
+				LinuxKernel.hide_unstable = false;
+				break;
+
 			case "--download":
 			case "--install":
 			case "--remove":

--- a/src/Console/AppConsole.vala
+++ b/src/Console/AppConsole.vala
@@ -57,6 +57,12 @@ public class AppConsole : GLib.Object {
 		
 		LOG_TIMESTAMP = false;
 
+		//check dependencies
+		string message;
+		if (!Main.check_dependencies(out message)) {
+			exit(1);
+		}
+
 		App = new Main(args, false);
 		
 		var console =  new AppConsole();


### PR DESCRIPTION
I'd like to be able to use ukuu on the command-line to install unstable kernels.  I know it should be possible to just edit the config file, but having a command-line option would be more convenient for initial deployments.
The patch is pretty trivial, and it works.  At least on 18.04.  It's not doing anything version-specific, so I don't see why it wouldn't work everywhere.