### PR TITLE
Allow --install-latest to install unstable/RC kernels if the user has requested to see unstable/RC kernels

### DIFF
--- a/src/Common/LinuxKernel.vala
+++ b/src/Common/LinuxKernel.vala
@@ -632,7 +632,7 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 			}
 			
 			// skip unstable
-			if (kern.is_unstable){
+			if (hide_unstable && kern.is_unstable){
 				continue;
 			}
 


### PR DESCRIPTION
It's a little bit of a goink that --install-latest doesn't install the latest kernel that --list shows the user when they've requested to see unstable releases.