### PR TITLE
Add --show-unstable to CLI to allow ability to show/install unstable and RC releases

### DIFF
--- a/src/Console/AppConsole.vala
+++ b/src/Console/AppConsole.vala
@@ -93,6 +93,7 @@ public class AppConsole : GLib.Object {
 		msg += "  --purge-old-kernels " + _("Remove installed kernels older than running kernel") + "\n";
 		msg += "  --download <name>   " + _("Download packages for specified kernel") + "\n";
 		msg += "  --clean-cache       " + _("Remove files from application cache") + "\n";
+		msg += "  --show-unstable     " + _("Show unstable and RC releases") + "\n";
 		msg += "\n";
 		msg += _("Options") + ":\n";
 		msg += "\n";
@@ -171,6 +172,10 @@ public class AppConsole : GLib.Object {
 				cmd = args[k].down();
 				break;
 			
+			case "--show-unstable":
+				LinuxKernel.hide_unstable = false;
+				break;
+
 			case "--download":
 			case "--install":
 			case "--remove":


### PR DESCRIPTION
This PR is just to add a --show-unstable command line arg to the CLI, so that it's not necessary to make (or have) a config file in order to be able to see unstable/RC releases.