### PR TITLE
CLI should also check for dependencies

### DIFF
--- a/src/Console/AppConsole.vala
+++ b/src/Console/AppConsole.vala
@@ -57,6 +57,12 @@ public class AppConsole : GLib.Object {
 		
 		LOG_TIMESTAMP = false;
 
+		//check dependencies
+		string message;
+		if (!Main.check_dependencies(out message)) {
+			exit(1);
+		}
+
 		App = new Main(args, false);
 		
 		var console =  new AppConsole();


### PR DESCRIPTION
I'm a first-time user, and the missing deps check tripped me up -- I had to turn on debugging output to figure out that it was trying and failing to run aria2c right before I got the "g_strsplit: assertion 'string != NULL' failed" and ukuu didn't load any kernel list.