### PR TITLE
Fix displaying of the ukuu's icon on Wayland-based DEs

### DIFF
--- a/src/ukuu.desktop
+++ b/src/ukuu.desktop
@@ -11,3 +11,4 @@ Comment=Kernel Update Utility
 Comment[ru]=Программа обновления ядра
 X-KDE-StartupNotify=false
 Categories=System;
+StartupWMClass=ukuu-gtk


### PR DESCRIPTION
From:
![image](https://user-images.githubusercontent.com/5782198/51500250-aed1d880-1dcd-11e9-8723-7fef70c91136.png)

To:
![image](https://user-images.githubusercontent.com/5782198/51500278-c4df9900-1dcd-11e9-95d1-33ac16cc5751.png)

